### PR TITLE
fix geo url (RFC5870) format

### DIFF
--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -179,7 +179,7 @@ L.OSM.Map = L.Map.extend({
     params.lon = latLng.lng.toFixed(precision);
     params.zoom = this.getZoom();
 
-    return 'geo:' + params.lat + ',' + params.lon + '?z=' + params.zoom;
+    return 'geo:' + params.lat + ',' + params.lon + ';z=' + params.zoom;
   },
 
   addObject: function(object, callback) {


### PR DESCRIPTION
when looking into [RFC5870](https://tools.ietf.org/rfc/rfc5870), parameters are separated using semicolon. Question marks are not allowed for the URI Scheme Syntax
